### PR TITLE
allow and test on rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ addons:
 rvm:
   - 2.4.1
 env:
-  - RAILS_REQ="~> 5.0.0" PG_REQ="~> 0.18"
-  - RAILS_REQ="~> 5.1.0"
-  - RAILS_REQ=">= 5.2.0.rc2,< 5.3.0"
+  - RAILS_GEM="~> 5.0.0" PG_GEM="~> 0.18"
+  - RAILS_GEM="~> 5.1.0"
+  - RAILS_GEM=">= 5.2.0.rc2,< 5.3.0"
 before_install: gem install bundler -v 1.14.6
 before_script:
   - bundle exec rake db:create

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 rvm:
   - 2.4.1
 env:
-  - RAILS_REQ="~> 5.0.0"
+  - RAILS_REQ="~> 5.0.0" PG_REQ="~> 0.18"
   - RAILS_REQ="~> 5.1.0"
   - RAILS_REQ=">= 5.2.0.rc2,< 5.3.0"
 before_install: gem install bundler -v 1.14.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ addons:
 rvm:
   - 2.4.1
 env:
-  - RAILS_SPEC="~> 5.0.0"
-  - RAILS_SPEC="~> 5.1.0"
+  - RAILS_REQ="~> 5.0.0"
+  - RAILS_REQ="~> 5.1.0"
+  - RAILS_REQ=">= 5.2.0.rc2,< 5.3.0"
 before_install: gem install bundler -v 1.14.6
 before_script:
   - bundle exec rake db:create

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,10 @@ if ENV['RAILS_REQ']
   gem "railties", ENV['RAILS_REQ'].split(",")
 end
 
+# Rails 5.0 won't work with pg 1.0, but that isn't actually in it's gemspec,
+# workaround.
+if ENV['PG_REQ']
+  gem "pg", ENV['PG_REQ']
+end
+
 gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,18 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in json_attribute.gemspec
 gemspec
 
+# Hopefully temporary, so we can test under rails 5.2
+# https://github.com/thuss/standalone-migrations/pull/142
+gem 'standalone_migrations', git: "https://github.com/jrochkind/standalone-migrations.git", branch: "ar_5_2"
+
 if ENV['RAILS_REQ']
   gem "activerecord", ENV['RAILS_REQ'].split(",")
+
+  # This shouldn't really be needed, but seems to maybe be a bundler bug,
+  # this makes standalone_migrations dependencies resolve properly even when our
+  # RAILS_REQ is for 5.2.0.rc2. If in the future you delete this and everything
+  # still passes, feel free to remove.
+  gem "railties", ENV['RAILS_REQ'].split(",")
 end
 
 gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -7,20 +7,20 @@ gemspec
 # https://github.com/thuss/standalone-migrations/pull/142
 gem 'standalone_migrations', git: "https://github.com/jrochkind/standalone-migrations.git", branch: "ar_5_2"
 
-if ENV['RAILS_REQ']
-  gem "activerecord", ENV['RAILS_REQ'].split(",")
+if ENV['RAILS_GEM']
+  gem "activerecord", ENV['RAILS_GEM'].split(",")
 
   # This shouldn't really be needed, but seems to maybe be a bundler bug,
   # this makes standalone_migrations dependencies resolve properly even when our
   # RAILS_REQ is for 5.2.0.rc2. If in the future you delete this and everything
   # still passes, feel free to remove.
-  gem "railties", ENV['RAILS_REQ'].split(",")
+  gem "railties", ENV['RAILS_GEM'].split(",")
 end
 
 # Rails 5.0 won't work with pg 1.0, but that isn't actually in it's gemspec,
-# workaround.
-if ENV['PG_REQ']
-  gem "pg", ENV['PG_REQ']
+# workaround, specify PG_GEM too with RAILS_GEM including 5.0.
+if ENV['PG_GEM']
+  gem "pg", ENV['PG_GEM']
 end
 
 gem "byebug"

--- a/json_attribute.gemspec
+++ b/json_attribute.gemspec
@@ -35,7 +35,7 @@ existing ActiveRecord architecture as we can.}
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 5.0.0", "< 5.2"
+  spec.add_runtime_dependency "activerecord", ">= 5.0.0", "< 5.3"
   spec.add_runtime_dependency "pg", ">= 0.18.1"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
* needs to point to local branch of `standalone_migrations` until that one allows 5.2
* including 5.2.rc2, which is what's out now
* fixed bug where .travis didn't use new ENV name
* weird hack needed in Gemfile, not sure why